### PR TITLE
fix: update macro argument types in macros.yml for dbt Fusion compatibility

### DIFF
--- a/macros/macros.yml
+++ b/macros/macros.yml
@@ -6,7 +6,7 @@ macros:
     description: Primary macro automatically called `on-run-end` to generate primary keys, unique keys, and foreign keys. The `dbt_constraints_enabled` variable can be set to `false` in your project to disable this macro.
     arguments:
       - name: constraint_types
-        type: array of constraint types
+        type: list[string]
         description: Accepts a list of tests to consider for constraint creation and whether columns should be quoted. By default it will create all the constraint types. Valid values are ['primary_key', 'unique_key', 'unique_combination_of_columns', 'unique', 'foreign_key', 'relationships']
       - name: quote_columns
         type: boolean
@@ -20,10 +20,10 @@ macros:
     description: Calls the adapter-specific version of the macro to create a primary key
     arguments:
       - name: table_model
-        type: graph node
+        type: relation
         description: Accepts the graph node of the table that will have the constraint
       - name: column_names
-        type: array of column names
+        type: list[string]
         description: An array of text column names to include in the constraint
       - name: quote_columns
         type: boolean
@@ -38,10 +38,10 @@ macros:
     description: Calls the adapter-specific version of the macro to create a unique key
     arguments:
       - name: table_model
-        type: graph node
+        type: relation
         description: Accepts the graph node of the table that will have the constraint
       - name: column_names
-        type: array of column names
+        type: list[string]
         description: An array of text column names to include in the constraint
       - name: quote_columns
         type: boolean
@@ -55,20 +55,17 @@ macros:
   - name: create_foreign_key
     description: Calls the adapter-specific version of the macro to create a foreign key
     arguments:
-      - name: test_model
-        type: results node
-        description: Accepts the result node of the test related to this constraint
-      - name: pk_model
-        type: graph node
+      - name: pk_table_relation
+        type: relation
         description: Accepts the graph node of the parent table that has a PK or UK
-      - name: column_names
-        type: array of column names
+      - name: pk_column_names
+        type: list[string]
         description: An array of text column names to include in the FK reference
-      - name: fk_model
-        type: graph node
+      - name: fk_table_relation
+        type: relation
         description: Accepts the graph node of the table that will have the constraint
       - name: fk_column_names
-        type: array of column names
+        type: list[string]
         description: An array of text column names to include in the constraint
       - name: quote_columns
         type: boolean
@@ -86,7 +83,7 @@ macros:
         type: relation
         description: Accepts the relation of the table to check
       - name: column_names
-        type: array of column names
+        type: list[string]
         description: An array of text column names the constraint must contain
     docs:
       show: true
@@ -98,7 +95,7 @@ macros:
         type: relation
         description: Accepts the relation of the table to check
       - name: column_names
-        type: array of column names
+        type: list[string]
         description: An array of text column names the constraint must contain
     docs:
       show: true


### PR DESCRIPTION
## Summary

`macros/macros.yml` uses free-form type strings that dbt Fusion's macro-argument validator (error code `dbt1506`) does not recognise, producing 16 non-blocking warnings on every `dbt parse`. This PR replaces them with valid types from Fusion's supported set and aligns `create_foreign_key`'s documented argument names with the actual macro signature.

**Type string fixes**

| Before | After |
|---|---|
| `array of constraint types` | `list[string]` |
| `array of column names` | `list[string]` |
| `graph node` | `relation` |
| `results node` | `any` |

**`create_foreign_key` argument name fixes**

The documented argument names did not match the actual macro parameters, producing four additional `"documented argument not found in macro definition"` dbt1506 warnings:

| Before | After |
|---|---|
| `test_model` (spurious, removed) | _(removed)_ |
| `pk_model` | `pk_table_relation` |
| `column_names` | `pk_column_names` |
| `fk_model` | `fk_table_relation` |

## Test plan

- [x] Ran `dbt parse` with dbt Fusion `2.0.0-preview.175` against a project that installs this package as a local path dependency — **16 dbt1506 warnings before, 0 after**.

## Release note

Once merged, a new package release will be needed for users to pick up the fix via `dbt deps`.

Relates to issue #118.