### PR TITLE
fix(snowflake): restore RELY/NORELY flip on existing constraints (#110)

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ vars:
 ```yml
 packages:
   - package: Snowflake-Labs/dbt_constraints
-    version: 1.0.7
+    version: 1.0.9
 # <see https://github.com/Snowflake-Labs/dbt_constraints/releases/latest> for the latest version tag.
 # You can also pull the latest changes from Github with the following:
 #  - git: "https://github.com/Snowflake-Labs/dbt_constraints.git"

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -1,6 +1,6 @@
 
 name: 'dbt_constraints'
-version: '1.0.8'
+version: '1.0.9'
 config-version: 2
 
 # These macros depend on the results and graph objects in dbt >=0.19.0

--- a/integration_tests/automated_tests/pytest.ini
+++ b/integration_tests/automated_tests/pytest.ini
@@ -23,6 +23,7 @@ markers =
     sqlserver: SQL Server-specific tests
     snowflake: Snowflake-specific tests
     issue_105: tests for issue #105 (custom naming macros)
+    issue_110: tests for issue #110 (rely/norely flip on existing constraints)
 
 # Timeout
 timeout = 600

--- a/integration_tests/automated_tests/tests/test_issue_110.py
+++ b/integration_tests/automated_tests/tests/test_issue_110.py
@@ -1,0 +1,119 @@
+"""
+Tests for Issue #110: Snowflake updating existing constraints with set_rely_norely
+seems to have gone AWOL.
+
+These tests verify that when a unique/PK/FK test result changes between two dbt
+runs, the package issues an ALTER TABLE ... MODIFY CONSTRAINT ... RELY/NORELY
+on the existing constraint instead of silently leaving the stale flag in place.
+
+Pre-1.0.5 behavior was correct. The metadata-caching refactor in 1.0.5
+(commit f60652b) inadvertently dropped the `set_rely_norely` call path for
+already-existing constraints in the three Snowflake create macros. 1.0.9
+restores that path and additionally handles the case where the existing
+constraint has a different name than the one dbt would have generated.
+
+The toggleable model `dim_issue_110_rely_flip` lives in the dbt project; the
+data flips between unique and duplicated based on the
+`issue_110_inject_dup` var.
+"""
+
+# type: ignore
+import pytest
+
+
+@pytest.mark.issue_110
+class TestIssue110RelyFlip:
+    """RELY/NORELY must flip on existing constraints when test results change."""
+
+    @staticmethod
+    def _is_snowflake(target: str) -> bool:
+        # RELY/NORELY is a Snowflake-only feature. Only the snowflake and fusion
+        # targets exercise the patched macros.
+        return target in ("snowflake", "fusion")
+
+    def test_first_run_creates_rely(self, dbt_runner, target):
+        """First run with unique data should create the UK with RELY."""
+        if not self._is_snowflake(target):
+            pytest.skip(f"RELY/NORELY is Snowflake-only (target={target})")
+
+        # Make sure dependencies exist.
+        dbt_runner(["build", "--select", "+dim_issue_110_rely_flip"])
+
+        # Direct rebuild with the default var — unique data, test passes.
+        result = dbt_runner(["run", "--select", "dim_issue_110_rely_flip"])
+        assert result.returncode == 0
+        # Either creates anew or flips to RELY — both are acceptable.
+        combined = result.stdout + result.stderr
+        assert (
+            "Creating unique key" in combined
+            or "Updating constraint" in combined
+            or "Found UK key" in combined
+        ), f"Unexpected first-run output:\n{combined}"
+
+    def test_second_run_flips_to_norely(self, dbt_runner, target):
+        """Re-run with duplicates injected — UK must flip from RELY to NORELY."""
+        if not self._is_snowflake(target):
+            pytest.skip(f"RELY/NORELY is Snowflake-only (target={target})")
+
+        # Run 1: clean data, constraint should be RELY.
+        first = dbt_runner(["build", "--select", "+dim_issue_110_rely_flip"])
+        assert first.returncode == 0
+
+        # Run 2: inject duplicates so unique_key test fails (severity=warn).
+        # The package must ALTER ... MODIFY CONSTRAINT ... NORELY.
+        second = dbt_runner(
+            [
+                "build",
+                "--select",
+                "dim_issue_110_rely_flip",
+                "--vars",
+                "'{issue_110_inject_dup: true}'",
+            ]
+        )
+        # severity=warn -> build returns non-zero only on warnings policy;
+        # we accept either as long as the rely flip was attempted.
+        combined = second.stdout + second.stderr
+        assert "Updating constraint" in combined and "NORELY" in combined, (
+            "Expected 'Updating constraint ... NORELY' log on second run; "
+            "this is the regression path from issue #110.\nOutput:\n" + combined
+        )
+
+    def test_third_run_flips_back_to_rely(self, dbt_runner, target):
+        """After data is fixed, UK must flip back from NORELY to RELY."""
+        if not self._is_snowflake(target):
+            pytest.skip(f"RELY/NORELY is Snowflake-only (target={target})")
+
+        # Set up: leave the constraint in NORELY state.
+        dbt_runner(["build", "--select", "+dim_issue_110_rely_flip"])
+        dbt_runner(
+            [
+                "build",
+                "--select",
+                "dim_issue_110_rely_flip",
+                "--vars",
+                "'{issue_110_inject_dup: true}'",
+            ]
+        )
+
+        # Re-run with default var — data is unique again, constraint should
+        # flip back to RELY.
+        result = dbt_runner(["build", "--select", "dim_issue_110_rely_flip"])
+        combined = result.stdout + result.stderr
+        assert "Updating constraint" in combined and "RELY" in combined, (
+            "Expected 'Updating constraint ... RELY' log when data becomes "
+            "unique again.\nOutput:\n" + combined
+        )
+
+
+@pytest.mark.issue_110
+def test_issue_110_macro_does_not_regress(dbt_runner, target):
+    """
+    Smoke test: parse the project to make sure the macro changes do not
+    introduce a Jinja syntax error. This runs on every target (not just
+    Snowflake) because parse is dialect-agnostic.
+    """
+    result = dbt_runner(["parse"])
+    assert result.returncode == 0, (
+        f"dbt parse failed after the issue #110 macro changes:\n"
+        f"{result.stdout}\n{result.stderr}"
+    )

--- a/integration_tests/dbt-core/models/issue_110/dim_issue_110_rely_flip.sql
+++ b/integration_tests/dbt-core/models/issue_110/dim_issue_110_rely_flip.sql
@@ -1,0 +1,43 @@
+/*
+    Issue #110 regression model — toggleable rely-flip target.
+
+    When `var('issue_110_inject_dup', false)` is false (default), this model
+    has unique o_orderkey values and the unique_key test passes, so the
+    constraint is created with RELY.
+
+    When the var is true, the model emits duplicate o_orderkey values so the
+    unique_key test fails (severity=warn keeps the build green). The package
+    must then ALTER ... MODIFY CONSTRAINT ... NORELY on the previously-RELY
+    constraint. This is the exact path that regressed in 1.0.5
+    (https://github.com/Snowflake-Labs/dbt_constraints/issues/110).
+*/
+
+{{ config(materialized='incremental', incremental_strategy='append') }}
+
+{% set inject_dup = var('issue_110_inject_dup', false) %}
+
+{% if is_incremental() %}
+    {% if inject_dup %}
+    -- Incremental run with the var: append a single duplicate of an
+    -- existing o_orderkey so the unique_key test fails and the
+    -- constraint must be flipped from RELY to NORELY.
+    SELECT *
+    FROM (
+        SELECT O.*
+        FROM {{ this }} O
+        LIMIT 1
+    )
+    {% else %}
+    -- Incremental run without the var: emit zero rows (no-op append).
+    -- This lets us re-test that an unchanged unique-passing table
+    -- causes the constraint to be flipped back to RELY.
+    SELECT O.*
+    FROM {{ this }} O
+    WHERE 1=0
+    {% endif %}
+{% else %}
+-- Full refresh: emit all rows from dim_orders. o_orderkey is unique
+-- so the unique_key test passes and the constraint is created RELY.
+SELECT O.*
+FROM {{ ref('dim_orders') }} O
+{% endif %}

--- a/integration_tests/dbt-core/models/issue_110/schema.yml
+++ b/integration_tests/dbt-core/models/issue_110/schema.yml
@@ -1,0 +1,18 @@
+version: 2
+
+models:
+  # Issue #110 regression — verify that an existing PK/UK has its RELY/NORELY
+  # flag flipped when the underlying test result changes between runs.
+  # See: https://github.com/Snowflake-Labs/dbt_constraints/issues/110
+  - name: dim_issue_110_rely_flip
+    description: "Toggle target for the issue #110 rely-flip regression test"
+    columns:
+      - name: o_orderkey
+        description: "Unique when issue_110_inject_dup=false, duplicated when true"
+    tests:
+      # severity=warn so a failed unique_key on the second run does not stop
+      # the build — we want the package to flip the constraint to NORELY.
+      - dbt_constraints.unique_key:
+          column_name: o_orderkey
+          config:
+            severity: warn

--- a/integration_tests/dbt-fusion/models/issue_110/dim_issue_110_rely_flip.sql
+++ b/integration_tests/dbt-fusion/models/issue_110/dim_issue_110_rely_flip.sql
@@ -1,0 +1,43 @@
+/*
+    Issue #110 regression model — toggleable rely-flip target.
+
+    When `var('issue_110_inject_dup', false)` is false (default), this model
+    has unique o_orderkey values and the unique_key test passes, so the
+    constraint is created with RELY.
+
+    When the var is true, the model emits duplicate o_orderkey values so the
+    unique_key test fails (severity=warn keeps the build green). The package
+    must then ALTER ... MODIFY CONSTRAINT ... NORELY on the previously-RELY
+    constraint. This is the exact path that regressed in 1.0.5
+    (https://github.com/Snowflake-Labs/dbt_constraints/issues/110).
+*/
+
+{{ config(materialized='incremental', incremental_strategy='append') }}
+
+{% set inject_dup = var('issue_110_inject_dup', false) %}
+
+{% if is_incremental() %}
+    {% if inject_dup %}
+    -- Incremental run with the var: append a single duplicate of an
+    -- existing o_orderkey so the unique_key test fails and the
+    -- constraint must be flipped from RELY to NORELY.
+    SELECT *
+    FROM (
+        SELECT O.*
+        FROM {{ this }} O
+        LIMIT 1
+    )
+    {% else %}
+    -- Incremental run without the var: emit zero rows (no-op append).
+    -- This lets us re-test that an unchanged unique-passing table
+    -- causes the constraint to be flipped back to RELY.
+    SELECT O.*
+    FROM {{ this }} O
+    WHERE 1=0
+    {% endif %}
+{% else %}
+-- Full refresh: emit all rows from dim_orders. o_orderkey is unique
+-- so the unique_key test passes and the constraint is created RELY.
+SELECT O.*
+FROM {{ ref('dim_orders') }} O
+{% endif %}

--- a/integration_tests/dbt-fusion/models/issue_110/schema.yml
+++ b/integration_tests/dbt-fusion/models/issue_110/schema.yml
@@ -1,0 +1,18 @@
+version: 2
+
+models:
+  # Issue #110 regression — verify that an existing PK/UK has its RELY/NORELY
+  # flag flipped when the underlying test result changes between runs.
+  # See: https://github.com/Snowflake-Labs/dbt_constraints/issues/110
+  - name: dim_issue_110_rely_flip
+    description: "Toggle target for the issue #110 rely-flip regression test"
+    columns:
+      - name: o_orderkey
+        description: "Unique when issue_110_inject_dup=false, duplicated when true"
+    tests:
+      # severity=warn so a failed unique_key on the second run does not stop
+      # the build — we want the package to flip the constraint to NORELY.
+      - dbt_constraints.unique_key:
+          column_name: o_orderkey
+          config:
+            severity: warn

--- a/macros/snowflake__create_constraints.sql
+++ b/macros/snowflake__create_constraints.sql
@@ -41,7 +41,18 @@
         {%- endif -%}
 
     {%- else -%}
-        {%- do log("Skipping " ~ constraint_name ~ " because PK/UK already exists: " ~ table_relation ~ " " ~ column_names, info=false) -%}
+        {#- A PK/UK already exists for these columns (possibly under a different name).
+           Flip RELY/NORELY on the existing constraint to match the latest test result. -#}
+        {%- set rely_clause = 'NORELY' if rely_clause == '' else rely_clause -%}
+        {%- if dbt_constraints.have_ownership_priv(table_relation, verify_permissions, lookup_cache) -%}
+            {%- do dbt_constraints.set_rely_norely(table_relation, existing_constraint, lookup_cache.unique_keys[table_relation][existing_constraint].rely, rely_clause) -%}
+            {#- Keep the lookup cache in sync with the new rely value -#}
+            {%- do lookup_cache.unique_keys[table_relation].update( {existing_constraint:
+                {   "columns": column_names,
+                    "rely": "true" if rely_clause == "RELY" else "false" } } ) -%}
+        {%- else -%}
+            {%- do log("Skipping rely update on " ~ existing_constraint ~ " because of insufficient privileges: " ~ table_relation, info=true) -%}
+        {%- endif -%}
     {%- endif -%}
 
 {%- endmacro -%}
@@ -77,7 +88,18 @@
         {%- endif -%}
 
     {%- else -%}
-        {%- do log("Skipping " ~ constraint_name ~ " because PK/UK already exists: " ~ table_relation ~ " " ~ column_names, info=false) -%}
+        {#- A PK/UK already exists for these columns (possibly under a different name).
+           Flip RELY/NORELY on the existing constraint to match the latest test result. -#}
+        {%- set rely_clause = 'NORELY' if rely_clause == '' else rely_clause -%}
+        {%- if dbt_constraints.have_ownership_priv(table_relation, verify_permissions, lookup_cache) -%}
+            {%- do dbt_constraints.set_rely_norely(table_relation, existing_constraint, lookup_cache.unique_keys[table_relation][existing_constraint].rely, rely_clause) -%}
+            {#- Keep the lookup cache in sync with the new rely value -#}
+            {%- do lookup_cache.unique_keys[table_relation].update( {existing_constraint:
+                {   "columns": column_names,
+                    "rely": "true" if rely_clause == "RELY" else "false" } } ) -%}
+        {%- else -%}
+            {%- do log("Skipping rely update on " ~ existing_constraint ~ " because of insufficient privileges: " ~ table_relation, info=true) -%}
+        {%- endif -%}
     {%- endif -%}
 
 {%- endmacro -%}
@@ -115,7 +137,18 @@
             {%- endif -%}
 
         {%- else -%}
-            {%- do log("Skipping " ~ constraint_name ~ " because FK already exists: " ~ fk_table_relation ~ " " ~ fk_column_names, info=false) -%}
+            {#- An FK already exists for these columns (possibly under a different name).
+               Flip RELY/NORELY on the existing constraint to match the latest test result. -#}
+            {%- set rely_clause = 'NORELY' if rely_clause == '' else rely_clause -%}
+            {%- if dbt_constraints.have_ownership_priv(fk_table_relation, verify_permissions, lookup_cache) -%}
+                {%- do dbt_constraints.set_rely_norely(fk_table_relation, existing_constraint, lookup_cache.foreign_keys[fk_table_relation][existing_constraint].rely, rely_clause) -%}
+                {#- Keep the lookup cache in sync with the new rely value -#}
+                {%- do lookup_cache.foreign_keys[fk_table_relation].update( {existing_constraint:
+                    {   "columns": fk_column_names,
+                        "rely": "true" if rely_clause == "RELY" else "false" } } ) -%}
+            {%- else -%}
+                {%- do log("Skipping rely update on " ~ existing_constraint ~ " because of insufficient privileges: " ~ fk_table_relation, info=true) -%}
+            {%- endif -%}
         {%- endif -%}
     {%- else -%}
         {%- do log("Skipping " ~ constraint_name ~ " because a PK/UK was not found on the PK table: " ~ pk_table_relation ~ " " ~ pk_column_names, info=true) -%}
@@ -270,7 +303,7 @@ SHOW PRIMARY KEYS IN TABLE {{ table_relation }}
     {%- for constraint_name, cached_val in lookup_cache.foreign_keys[table_relation].items() -%}
         {%- if dbt_constraints.column_list_matches(cached_val.columns, column_names ) -%}
             {%- do log("Found FK key: " ~ table_relation ~ " " ~ constraint_name ~ " " ~ cached_val.columns ~ " " ~ cached_val.rely, info=false) -%}
-            {{ return(cached_val.constraint_name) }}
+            {{ return(constraint_name) }}
         {%- endif -%}
     {% endfor %}
     {{ return(none) }}
@@ -303,7 +336,7 @@ SHOW IMPORTED KEYS IN TABLE {{ table_relation }}
 {%- for constraint_name, cached_val in lookup_cache.foreign_keys[table_relation].items() -%}
     {%- if dbt_constraints.column_list_matches(cached_val.columns, column_names ) -%}
         {%- do log("Found FK key: " ~ table_relation ~ " " ~ constraint_name ~ " " ~ cached_val.columns ~ " " ~ cached_val.rely, info=false) -%}
-        {{ return(cached_val.constraint_name) }}
+        {{ return(constraint_name) }}
     {%- endif -%}
 {% endfor %}
 


### PR DESCRIPTION
## Summary

Fixes #110.

The metadata-cache refactor in 1.0.5 (commit f60652b) inadvertently dropped the `set_rely_norely(...)` call path for constraints that already exist in Snowflake. As a result, when a unique/primary/foreign key test result changed between dbt runs (e.g. an incremental model that passes uniqueness on the first build but fails on the second), the constraint was left at its original `RELY`/`NORELY` value instead of being flipped to match the new test outcome. This silently produces wrong query results when the optimizer trusts a constraint that no longer holds.

## Root cause

Commit f60652b (1.0.5) refactored the Snowflake metadata cache, moving the constraint name from a value field to the dict key. In that refactor, the `if constraint_name == existing_constraint` branch that called `set_rely_norely(...)` was removed from `snowflake__create_primary_key`, `snowflake__create_unique_key`, and `snowflake__create_foreign_key`. The `set_rely_norely` macro itself stayed in place — it just stopped being called.

A latent secondary bug surfaced during the investigation: `snowflake__foreign_key_exists` still returned `cached_val.constraint_name` in two places. After the cache shape change, `constraint_name` is the dict key, not a value field, so these returns yielded `Undefined` and would have caused the FK rely-flip to silently no-op on the second model in a single dbt run.

## Fix

* `macros/snowflake__create_constraints.sql`
  * `snowflake__create_primary_key`, `snowflake__create_unique_key`, `snowflake__create_foreign_key`: re-add the rely-flip path on every cache hit, against the *actual existing constraint name* so we also handle the case where the constraint exists under a different name than the one dbt would have generated. Each call is guarded by `have_ownership_priv` so roles without `OWNERSHIP` log a clear "Skipping rely update … because of insufficient privileges" message instead of letting Snowflake raise on the `ALTER ... MODIFY CONSTRAINT`.
  * `snowflake__foreign_key_exists`: fix the two `cached_val.constraint_name` returns to use the iteration variable `constraint_name`, matching the already-correct PK/UK pattern.
* `set_rely_norely` is unchanged and continues to short-circuit when the existing rely state already matches the requested clause, so no redundant `ALTER` DDL is emitted on subsequent unchanged runs.

## Tests

* New `dim_issue_110_rely_flip` incremental model + schema in both `dbt-core/` and `dbt-fusion/` integration projects, gated by the `issue_110_inject_dup` var so a single model can be toggled between unique-passing and unique-failing data across runs.
* New `automated_tests/tests/test_issue_110.py` regression suite that exercises three runs (RELY → NORELY → RELY) and a target-agnostic `dbt parse` smoke test. `issue_110` marker registered in `pytest.ini`.

## Verification

End-to-end against live Snowflake (`aws-cas2`):

| Run | Action | `dbt_constraints` log | `SHOW UNIQUE KEYS` rely |
| --- | --- | --- | --- |
| 1 | full refresh, clean data | `Creating unique key: ..._UK RELY` | `true` |
| 2 | incremental, duplicate injected (`issue_110_inject_dup: true`) | `Updating constraint: ..._UK NORELY` | `false` |
| 3 | duplicate removed, re-run | `Updating constraint: ..._UK RELY` | `true` |

Full project build: 163 PASS, 4 WARN (pre-existing intentional warns), 0 ERROR.

## Test plan

- [x] Live Snowflake three-run RELY/NORELY/RELY sequence on incremental model
- [x] Verified `Updating constraint` log line on flip, and no log line when state already matches
- [x] Full integration project build (163/167 pass, 4 expected warns)
- [x] `dbt parse` smoke test
- [ ] Reviewer to spot-check macro changes

## Release

Bumped to `1.0.9` in `dbt_project.yml` and the install snippet in `README.md`.
