### PR TITLE
chore(gitignore): ignore __pycache__, .snowflake/, *.code-workspace

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,8 @@ dmypy.json
 **/.taskmaster/**
 **/.cursor/**
 **/.dockerenv/**
+**/__pycache__/**
+
+# Local IDE / editor artifacts
+.snowflake/
+*.code-workspace


### PR DESCRIPTION
## Summary

Adds three legitimate gitignore patterns the repo currently misses, so common local artifacts no longer pollute `git status`:

* `**/__pycache__/**` — generated by every Python invocation under `integration_tests/automated_tests/`. Without this, pytest runs leave the working copy dirty.
* `.snowflake/` — local Cortex Code session state (plans, etc.).
* `*.code-workspace` — VS Code workspace files generated when editing this repo from a multi-root workspace.

None of these should ever be committed.

## Test plan

- [x] After applying, `git status --ignored` shows the new directories as ignored
- [x] No previously-tracked files are accidentally ignored (verified via `git ls-files | xargs git check-ignore` returns nothing)
