### PR TITLE
test-infra: add testcontainers-python fixtures for db & dbt runners

### DIFF
--- a/integration_tests/automated_tests/database_fixtures.py
+++ b/integration_tests/automated_tests/database_fixtures.py
@@ -1,0 +1,401 @@
+"""
+Database fixtures using testcontainers-python.
+
+This module provides database container fixtures similar to the Java testutil fixtures
+in the Snowflake-Arrow-Agent project. Each fixture manages a database container lifecycle
+and provides connection information.
+
+Usage:
+    # In conftest.py
+    from database_fixtures import PostgresFixture, OracleFixture, SqlServerFixture
+
+    @pytest.fixture(scope="session")
+    def postgres_container():
+        with PostgresFixture() as fixture:
+            yield fixture
+
+    # In tests
+    def test_something(postgres_container):
+        creds = postgres_container.get_credentials()
+        # Use creds["host"], creds["port"], etc.
+"""
+
+import logging
+import secrets
+import string
+from abc import ABC, abstractmethod
+from contextlib import contextmanager
+from typing import Any
+
+from testcontainers.core.container import DockerContainer
+from testcontainers.core.waiting_utils import wait_for_logs
+from testcontainers.mssql import SqlServerContainer
+from testcontainers.postgres import PostgresContainer
+
+logger = logging.getLogger(__name__)
+
+
+def generate_secure_password(length: int = 16, oracle_safe: bool = False) -> str:
+    """Generate a secure random password.
+
+    Args:
+        length: Password length
+        oracle_safe: If True, exclude characters that cause issues in Oracle SQL
+    """
+    # Oracle has issues with & (substitution variable) and backslash (escape char)
+    special_chars = "!@#$%^*" if oracle_safe else "!@#$%^&*"
+    alphabet = string.ascii_letters + string.digits + special_chars
+
+    # Ensure at least one of each type
+    password = [
+        secrets.choice(string.ascii_lowercase),
+        secrets.choice(string.ascii_uppercase),
+        secrets.choice(string.digits),
+        secrets.choice(special_chars),
+    ]
+    # Fill the rest
+    password.extend(secrets.choice(alphabet) for _ in range(length - 4))
+    # Shuffle
+    secrets.SystemRandom().shuffle(password)
+    return "".join(password)
+
+
+def generate_db_identifier(prefix: str = "test") -> str:
+    """Generate a random database identifier."""
+    return f"{prefix}_{secrets.token_hex(4)}"
+
+
+class AbstractDatabaseFixture(ABC):
+    """
+    Abstract base class for database test fixtures.
+
+    Similar to the Java AbstractAgentFixture pattern, this provides common
+    functionality for all database-specific fixtures.
+    """
+
+    def __init__(self):
+        self._container = None
+        self._started = False
+
+    @abstractmethod
+    def start(self) -> None:
+        """Start the database container."""
+        pass
+
+    @abstractmethod
+    def stop(self) -> None:
+        """Stop the database container."""
+        pass
+
+    @abstractmethod
+    def get_credentials(self) -> dict[str, Any]:
+        """Get connection credentials for this database.
+
+        Returns:
+            Dictionary with keys: host, port, user, password, database
+        """
+        pass
+
+    @abstractmethod
+    def get_database_type(self) -> str:
+        """Return the database type identifier (e.g., 'postgres', 'oracle')."""
+        pass
+
+    def is_running(self) -> bool:
+        """Check if the container is running."""
+        return self._started and self._container is not None
+
+    def __enter__(self):
+        """Context manager entry - starts the container."""
+        self.start()
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        """Context manager exit - stops the container."""
+        self.stop()
+        return False
+
+
+class PostgresFixture(AbstractDatabaseFixture):
+    """
+    PostgreSQL database fixture using testcontainers.
+
+    Provides a PostgreSQL 17 container for integration testing.
+
+    Example:
+        with PostgresFixture() as fixture:
+            creds = fixture.get_credentials()
+            # Connect using creds["host"], creds["port"], etc.
+    """
+
+    DEFAULT_IMAGE = "postgres:17-alpine"
+
+    def __init__(self, image: str | None = None):
+        super().__init__()
+        self._image = image or self.DEFAULT_IMAGE
+        self._user = generate_db_identifier("dbtusr")
+        self._password = generate_secure_password()
+        self._database = generate_db_identifier("dbtdb")
+
+    def start(self) -> None:
+        if self._started:
+            logger.warning("PostgreSQL container already started")
+            return
+
+        logger.info(f"Starting PostgreSQL container: {self._image}")
+        self._container = PostgresContainer(
+            image=self._image,
+            username=self._user,
+            password=self._password,
+            dbname=self._database,
+        )
+        self._container.start()
+        self._started = True
+        logger.info(
+            f"✅ PostgreSQL started on port {self._container.get_exposed_port(5432)}"
+        )
+
+    def stop(self) -> None:
+        if not self._started:
+            return
+
+        logger.info("Stopping PostgreSQL container")
+        if self._container:
+            self._container.stop()
+            self._container = None
+        self._started = False
+        logger.info("✅ PostgreSQL stopped")
+
+    def get_credentials(self) -> dict[str, Any]:
+        if not self._container:
+            raise RuntimeError("PostgreSQL container is not running")
+
+        return {
+            "host": self._container.get_container_host_ip(),
+            "port": self._container.get_exposed_port(5432),
+            "user": self._user,
+            "password": self._password,
+            "database": self._database,
+        }
+
+    def get_database_type(self) -> str:
+        return "postgres"
+
+    def get_connection_url(self) -> str:
+        """Get SQLAlchemy-compatible connection URL."""
+        if not self._container:
+            raise RuntimeError("PostgreSQL container is not running")
+        return self._container.get_connection_url()
+
+
+class OracleFixture(AbstractDatabaseFixture):
+    """
+    Oracle database fixture using testcontainers GenericContainer.
+
+    Uses the official Oracle Free image for ARM64/x64 compatibility.
+
+    Example:
+        with OracleFixture() as fixture:
+            creds = fixture.get_credentials()
+            # Connect using creds["host"], creds["port"], etc.
+
+    Note:
+        - First run may be slow (pulls Oracle Free image ~2GB)
+        - Oracle Free container requires significant memory (~2GB)
+        - Uses SYSTEM user with auto-generated password
+    """
+
+    # Oracle Free - official Oracle container with ARM64 support
+    DEFAULT_IMAGE = "gvenzl/oracle-free:23-slim-faststart"
+    ORACLE_PORT = 1521
+    SERVICE_NAME = "FREEPDB1"
+
+    def __init__(self, image: str | None = None):
+        super().__init__()
+        self._image = image or self.DEFAULT_IMAGE
+        # Oracle requires uppercase user names and strong passwords
+        self._user = generate_db_identifier("DBTUSR").upper()
+        self._password = generate_secure_password(20, oracle_safe=True)
+
+    def start(self) -> None:
+        if self._started:
+            logger.warning("Oracle container already started")
+            return
+
+        logger.info(
+            f"Starting Oracle container: {self._image} (this may take several minutes)"
+        )
+
+        # Using GenericContainer for Oracle as there's no official testcontainers-oracle for Python
+        self._container = DockerContainer(image=self._image)
+        self._container.with_exposed_ports(self.ORACLE_PORT)
+        self._container.with_env("ORACLE_PASSWORD", self._password)
+        self._container.with_env("APP_USER", self._user)
+        self._container.with_env("APP_USER_PASSWORD", self._password)
+
+        self._container.start()
+
+        # Wait for Oracle to be ready
+        wait_for_logs(
+            self._container,
+            "DATABASE IS READY TO USE",
+            timeout=300,  # 5 minutes timeout
+        )
+
+        self._started = True
+        logger.info(
+            f"✅ Oracle started on port {self._container.get_exposed_port(self.ORACLE_PORT)}"
+        )
+
+    def stop(self) -> None:
+        if not self._started:
+            return
+
+        logger.info("Stopping Oracle container")
+        if self._container:
+            self._container.stop()
+            self._container = None
+        self._started = False
+        logger.info("✅ Oracle stopped")
+
+    def get_credentials(self) -> dict[str, Any]:
+        if not self._container:
+            raise RuntimeError("Oracle container is not running")
+
+        return {
+            "host": self._container.get_container_host_ip(),
+            "port": self._container.get_exposed_port(self.ORACLE_PORT),
+            "user": self._user,
+            "password": self._password,
+            "database": self.SERVICE_NAME,
+            "service": self.SERVICE_NAME,
+        }
+
+    def get_database_type(self) -> str:
+        return "oracle"
+
+    def get_jdbc_url(self) -> str:
+        """Get JDBC-style connection URL."""
+        creds = self.get_credentials()
+        return f"jdbc:oracle:thin:@{creds['host']}:{creds['port']}/{creds['service']}"
+
+
+class SqlServerFixture(AbstractDatabaseFixture):
+    """
+    SQL Server database fixture using testcontainers.
+
+    Uses the official Microsoft SQL Server 2022 image.
+
+    Example:
+        with SqlServerFixture() as fixture:
+            creds = fixture.get_credentials()
+            # Connect using creds["host"], creds["port"], etc.
+
+    Note:
+        - Requires acceptance of Microsoft EULA (handled automatically)
+        - First run may be slow (pulls SQL Server image)
+    """
+
+    DEFAULT_IMAGE = "mcr.microsoft.com/mssql/server:2022-latest"
+
+    def __init__(self, image: str | None = None):
+        super().__init__()
+        self._image = image or self.DEFAULT_IMAGE
+        # SQL Server requires 'sa' user and complex passwords
+        self._user = "sa"
+        self._password = generate_secure_password(20)
+        self._database = "master"
+
+    def start(self) -> None:
+        if self._started:
+            logger.warning("SQL Server container already started")
+            return
+
+        logger.info(f"Starting SQL Server container: {self._image}")
+
+        self._container = SqlServerContainer(
+            image=self._image,
+            password=self._password,
+        )
+        self._container.start()
+        self._started = True
+        logger.info(
+            f"✅ SQL Server started on port {self._container.get_exposed_port(1433)}"
+        )
+
+    def stop(self) -> None:
+        if not self._started:
+            return
+
+        logger.info("Stopping SQL Server container")
+        if self._container:
+            self._container.stop()
+            self._container = None
+        self._started = False
+        logger.info("✅ SQL Server stopped")
+
+    def get_credentials(self) -> dict[str, Any]:
+        if not self._container:
+            raise RuntimeError("SQL Server container is not running")
+
+        return {
+            "host": self._container.get_container_host_ip(),
+            "port": self._container.get_exposed_port(1433),
+            "user": self._user,
+            "password": self._password,
+            "database": self._database,
+        }
+
+    def get_database_type(self) -> str:
+        return "sqlserver"
+
+    def get_connection_url(self) -> str:
+        """Get SQLAlchemy-compatible connection URL."""
+        if not self._container:
+            raise RuntimeError("SQL Server container is not running")
+        return self._container.get_connection_url()
+
+
+# Fixture factory for easy access
+FIXTURE_CLASSES = {
+    "postgres": PostgresFixture,
+    "oracle": OracleFixture,
+    "sqlserver": SqlServerFixture,
+}
+
+
+def create_database_fixture(database_type: str) -> AbstractDatabaseFixture:
+    """
+    Factory function to create a database fixture by type.
+
+    Args:
+        database_type: One of 'postgres', 'oracle', 'sqlserver'
+
+    Returns:
+        Appropriate database fixture instance
+    """
+    if database_type not in FIXTURE_CLASSES:
+        raise ValueError(
+            f"Unknown database type: {database_type}. "
+            f"Available: {list(FIXTURE_CLASSES.keys())}"
+        )
+
+    return FIXTURE_CLASSES[database_type]()
+
+
+@contextmanager
+def database_fixture(database_type: str):
+    """
+    Context manager for database fixtures.
+
+    Example:
+        with database_fixture("postgres") as fixture:
+            creds = fixture.get_credentials()
+            # Use the database
+    """
+    fixture = create_database_fixture(database_type)
+    try:
+        fixture.start()
+        yield fixture
+    finally:
+        fixture.stop()

--- a/integration_tests/automated_tests/dbt_fixtures.py
+++ b/integration_tests/automated_tests/dbt_fixtures.py
@@ -1,0 +1,459 @@
+"""
+dbt runner fixtures using testcontainers-python.
+
+This module provides dbt runner container fixtures that build and run dbt
+commands in isolated Docker containers. Uses Testcontainers for container
+lifecycle management and exposed host ports for database connectivity.
+
+Based on testcontainers patterns from:
+https://testcontainers-python.readthedocs.io/en/latest/modules/generic/README.html
+
+Usage:
+    # In conftest.py
+    from dbt_fixtures import DbtCoreRunnerFixture, DbtFusionRunnerFixture
+
+    @pytest.fixture(scope="function")
+    def dbt_runner(database, dbt_version, db_credentials):
+        with DbtCoreRunnerFixture(database, dbt_version, db_credentials) as runner:
+            yield runner.run_command
+"""
+
+import logging
+from abc import ABC, abstractmethod
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+
+from testcontainers.core.container import DockerContainer
+from testcontainers.core.image import DockerImage
+
+logger = logging.getLogger(__name__)
+
+# Get directories relative to this file
+_THIS_DIR = Path(__file__).parent
+_INTEGRATION_TESTS_DIR = _THIS_DIR.parent
+_PROJECT_ROOT = _INTEGRATION_TESTS_DIR.parent
+
+# Docker host address for container-to-host networking
+DOCKER_HOST_INTERNAL = "host.docker.internal"
+
+
+class AbstractDbtRunnerFixture(ABC):
+    """
+    Abstract base class for dbt runner fixtures.
+
+    Provides common functionality for building and running dbt containers.
+    Subclasses implement database/engine-specific configuration.
+
+    Uses testcontainers DockerImage for building (with Docker layer caching)
+    and DockerContainer for running, following the pattern from:
+    https://testcontainers-python.readthedocs.io/en/latest/modules/generic/README.html
+    """
+
+    def __init__(
+        self,
+        database: str,
+        dbt_version: str,
+        db_credentials: dict[str, str],
+        project_dir: str = "dbt-core",
+    ):
+        """
+        Initialize a dbt runner fixture.
+
+        Args:
+            database: Target database type (postgres, oracle, sqlserver, snowflake)
+            dbt_version: dbt version to install (e.g., "1.9.0")
+            db_credentials: Database connection credentials dict
+            project_dir: dbt project directory name under integration_tests/
+        """
+        self._database = database
+        self._dbt_version = dbt_version
+        self._db_credentials = db_credentials
+        self._project_dir = project_dir
+        self._container: DockerContainer | None = None
+        self._image: DockerImage | None = None
+        self._image_tag: str | None = None
+
+    @property
+    @abstractmethod
+    def dockerfile_name(self) -> str:
+        """Dockerfile filename (e.g., 'Dockerfile' or 'Dockerfile.fusion')."""
+        pass
+
+    @property
+    @abstractmethod
+    def image_prefix(self) -> str:
+        """Image name prefix for this runner type."""
+        pass
+
+    @abstractmethod
+    def get_build_args(self) -> dict[str, str]:
+        """Get Docker build arguments for this runner."""
+        pass
+
+    @abstractmethod
+    def get_environment(self) -> dict[str, str]:
+        """Get environment variables for the container."""
+        pass
+
+    def _get_image_tag(self) -> str:
+        """Generate a unique image tag for this runner configuration."""
+        return f"{self.image_prefix}:{self._database}-{self._dbt_version}"
+
+    def _build_image(self) -> DockerImage:
+        """
+        Build the Docker image using testcontainers DockerImage.
+
+        Uses Docker's built-in layer caching for fast rebuilds.
+        The DockerImage class handles the build process and cleanup.
+
+        Returns:
+            DockerImage instance (manages the built image lifecycle)
+        """
+        tag = self._get_image_tag()
+        logger.info(f"🏗️  Building image: {tag}")
+
+        # Use testcontainers DockerImage for building
+        # path: build context directory (project root)
+        # dockerfile_path: relative path to Dockerfile within the context
+        # tag: image tag to apply
+        # buildargs: Docker build arguments
+        image = DockerImage(
+            path=str(_PROJECT_ROOT),
+            dockerfile_path=f"integration_tests/automated_tests/docker/build/{self.dockerfile_name}",
+            tag=tag,
+            buildargs=self.get_build_args(),
+            clean_up=False,  # Keep image for Docker layer caching across runs
+        )
+
+        # Build the image (testcontainers handles this in __enter__)
+        image.__enter__()
+        logger.info(f"✅ Built image: {tag}")
+
+        return image
+
+    def start(self) -> None:
+        """Build and start the dbt runner container."""
+        if self._container is not None:
+            logger.warning("Container already started")
+            return
+
+        # Build image using testcontainers DockerImage
+        self._image = self._build_image()
+        self._image_tag = self._get_image_tag()
+
+        # Create container with Testcontainers DockerContainer
+        # Following the pattern: DockerContainer(image=image) or with tag string
+        self._container = DockerContainer(image=self._image_tag)
+
+        # Set environment variables using with_env()
+        for key, value in self.get_environment().items():
+            self._container.with_env(key, value)
+
+        # Mount project directory for access to dbt project files
+        self._container.with_volume_mapping(
+            str(_PROJECT_ROOT),
+            "/project",
+            mode="rw",
+        )
+
+        # Set working directory
+        project_path = f"/project/integration_tests/{self._project_dir}"
+        self._container.with_kwargs(working_dir=project_path)
+
+        # Keep container running for multiple exec commands
+        self._container.with_command("tail -f /dev/null")
+
+        logger.info(f"🚀 Starting container: {self._image_tag}")
+        self._container.start()
+        logger.info(
+            f"✅ Container started: {self._container.get_wrapped_container().short_id}"
+        )
+
+    def stop(self) -> None:
+        """Stop and remove the container."""
+        if self._container is None:
+            return
+
+        logger.info("🛑 Stopping container")
+        try:
+            self._container.stop()
+        except Exception as e:
+            logger.warning(f"Error stopping container: {e}")
+        self._container = None
+
+        # Note: We don't call self._image.__exit__() here because we set
+        # clean_up=False to preserve Docker layer caching across test runs.
+        # The image will remain available for faster subsequent builds.
+        self._image = None
+
+        logger.info("✅ Container stopped")
+
+    def run_command(self, command: str, check: bool = True) -> dict[str, Any]:
+        """
+        Execute a command in the container.
+
+        Args:
+            command: Shell command to run
+            check: If True, raise exception on non-zero exit code
+
+        Returns:
+            Dict with keys: exit_code, stdout, stderr
+        """
+        if self._container is None:
+            raise RuntimeError("Container is not running")
+
+        wrapped = self._container.get_wrapped_container()
+        logger.info(f"▶️  Running: {command}")
+
+        exec_result = wrapped.exec_run(
+            cmd=["bash", "-c", command],
+            environment=self.get_environment(),
+            workdir=f"/project/integration_tests/{self._project_dir}",
+        )
+
+        exit_code = exec_result.exit_code
+        output = exec_result.output.decode("utf-8") if exec_result.output else ""
+
+        result = {
+            "exit_code": exit_code,
+            "stdout": output,
+            "stderr": "",  # exec_run combines stdout/stderr
+            "returncode": exit_code,  # Compatibility with subprocess
+        }
+
+        if check and exit_code != 0:
+            logger.error(f"❌ Command failed (exit {exit_code})")
+            logger.error(f"Output:\n{output}")
+            raise RuntimeError(
+                f"Command '{command}' failed with exit code {exit_code}\n"
+                f"Output:\n{output}"
+            )
+
+        logger.debug(f"✅ Command completed (exit {exit_code})")
+        return result
+
+    def get_run_function(self) -> Callable[[str, bool], dict[str, Any]]:
+        """Get a callable that runs commands in this container."""
+        return self.run_command
+
+    def __enter__(self):
+        """Context manager entry - starts the container."""
+        self.start()
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        """Context manager exit - stops the container."""
+        self.stop()
+        return False
+
+
+class DbtCoreRunnerFixture(AbstractDbtRunnerFixture):
+    """
+    dbt-core runner fixture for testing with standard dbt adapters.
+
+    Supports postgres, oracle, sqlserver, and snowflake databases.
+
+    Example:
+        with DbtCoreRunnerFixture("postgres", "1.9.0", creds) as runner:
+            runner.run_command("dbt deps")
+            runner.run_command("dbt seed")
+            result = runner.run_command("dbt run")
+    """
+
+    # Map database types to dbt adapter names
+    ADAPTER_MAP = {
+        "postgres": "postgres",
+        "oracle": "oracle",
+        "sqlserver": "sqlserver",
+        "snowflake": "snowflake",
+    }
+
+    @property
+    def dockerfile_name(self) -> str:
+        return "Dockerfile"
+
+    @property
+    def image_prefix(self) -> str:
+        return "dbt-constraints-test"
+
+    def get_build_args(self) -> dict[str, str]:
+        adapter = self.ADAPTER_MAP.get(self._database, self._database)
+        return {
+            "DBT_VERSION": self._dbt_version,
+            "DBT_ADAPTER": adapter,
+        }
+
+    def get_environment(self) -> dict[str, str]:
+        """Get environment variables including database credentials."""
+        env = {
+            "DBT_TARGET": self._database,
+            "DBT_PROJECT_DIR": f"/project/integration_tests/{self._project_dir}",
+            "DBT_PROFILES_DIR": f"/project/integration_tests/{self._project_dir}",
+        }
+
+        # Add database-specific environment variables
+        creds = self._db_credentials
+
+        if self._database == "postgres":
+            env.update(
+                {
+                    "POSTGRES_HOST": creds.get("host", DOCKER_HOST_INTERNAL),
+                    "POSTGRES_PORT": creds.get("port", "5432"),
+                    "POSTGRES_USER": creds.get("user", ""),
+                    "POSTGRES_PASSWORD": creds.get("password", ""),
+                    "POSTGRES_DB": creds.get("database", ""),
+                }
+            )
+
+        elif self._database == "oracle":
+            env.update(
+                {
+                    "ORACLE_HOST": creds.get("host", DOCKER_HOST_INTERNAL),
+                    "ORACLE_PORT": creds.get("port", "1521"),
+                    "ORACLE_USER": creds.get("user", ""),
+                    "ORACLE_PASSWORD": creds.get("password", ""),
+                    "ORACLE_SERVICE": creds.get("service", "FREEPDB1"),
+                    "ORACLE_DATABASE": creds.get("database", "FREEPDB1"),
+                }
+            )
+
+        elif self._database == "sqlserver":
+            env.update(
+                {
+                    "SQLSERVER_HOST": creds.get("host", DOCKER_HOST_INTERNAL),
+                    "SQLSERVER_PORT": creds.get("port", "1433"),
+                    "SQLSERVER_USER": creds.get("user", ""),
+                    "SQLSERVER_PASSWORD": creds.get("password", ""),
+                    "SQLSERVER_DATABASE": creds.get("database", "master"),
+                }
+            )
+
+        elif self._database == "snowflake":
+            # Map all Snowflake credential keys to environment variables
+            snowflake_env_map = {
+                "account": "SNOWFLAKE_ACCOUNT",
+                "user": "SNOWFLAKE_USER",
+                "password": "SNOWFLAKE_PASSWORD",
+                "private_key_path": "SNOWFLAKE_PRIVATE_KEY_PATH",
+                "private_key_passphrase": "SNOWFLAKE_PRIVATE_KEY_PASSPHRASE",
+                "role": "SNOWFLAKE_ROLE",
+                "database": "SNOWFLAKE_DATABASE",
+                "warehouse": "SNOWFLAKE_WAREHOUSE",
+                "schema": "SNOWFLAKE_SCHEMA",
+            }
+            for key, env_var in snowflake_env_map.items():
+                if key in creds:
+                    env[env_var] = creds[key]
+
+        return env
+
+
+class DbtFusionRunnerFixture(AbstractDbtRunnerFixture):
+    """
+    dbt-fusion runner fixture for testing with the Fusion engine.
+
+    Fusion is a Rust-based dbt execution engine that uses Snowflake as backend.
+
+    Example:
+        with DbtFusionRunnerFixture("1.0.0", snowflake_creds) as runner:
+            runner.run_command("dbt deps")
+            runner.run_command("dbt run")
+    """
+
+    def __init__(
+        self,
+        dbt_version: str,
+        db_credentials: dict[str, str],
+    ):
+        """
+        Initialize a Fusion runner fixture.
+
+        Args:
+            dbt_version: Fusion version (or "latest")
+            db_credentials: Snowflake connection credentials
+        """
+        super().__init__(
+            database="fusion",
+            dbt_version=dbt_version,
+            db_credentials=db_credentials,
+            project_dir="dbt-fusion",
+        )
+
+    @property
+    def dockerfile_name(self) -> str:
+        return "Dockerfile.fusion"
+
+    @property
+    def image_prefix(self) -> str:
+        return "dbt-constraints-fusion"
+
+    def get_build_args(self) -> dict[str, str]:
+        return {
+            "DBT_VERSION": self._dbt_version,
+        }
+
+    def get_environment(self) -> dict[str, str]:
+        """Get environment variables for Fusion with Snowflake backend."""
+        env = {
+            "DBT_TARGET": "snowflake",
+            "DBT_PROJECT_DIR": f"/project/integration_tests/{self._project_dir}",
+            "DBT_PROFILES_DIR": f"/project/integration_tests/{self._project_dir}",
+        }
+
+        # Map all Snowflake credential keys to environment variables
+        creds = self._db_credentials
+        snowflake_env_map = {
+            "account": "SNOWFLAKE_ACCOUNT",
+            "user": "SNOWFLAKE_USER",
+            "password": "SNOWFLAKE_PASSWORD",
+            "private_key_path": "SNOWFLAKE_PRIVATE_KEY_PATH",
+            "private_key_passphrase": "SNOWFLAKE_PRIVATE_KEY_PASSPHRASE",
+            "role": "SNOWFLAKE_ROLE",
+            "database": "SNOWFLAKE_DATABASE",
+            "warehouse": "SNOWFLAKE_WAREHOUSE",
+            "schema": "SNOWFLAKE_SCHEMA",
+        }
+        for key, env_var in snowflake_env_map.items():
+            if key in creds:
+                env[env_var] = creds[key]
+
+        return env
+
+
+# Fixture factory for easy access
+FIXTURE_CLASSES = {
+    "postgres": DbtCoreRunnerFixture,
+    "oracle": DbtCoreRunnerFixture,
+    "sqlserver": DbtCoreRunnerFixture,
+    "snowflake": DbtCoreRunnerFixture,
+    "fusion": DbtFusionRunnerFixture,
+}
+
+
+def create_dbt_runner_fixture(
+    database: str,
+    dbt_version: str,
+    db_credentials: dict[str, str],
+) -> AbstractDbtRunnerFixture:
+    """
+    Factory function to create a dbt runner fixture by database type.
+
+    Args:
+        database: Database type (postgres, oracle, sqlserver, snowflake, fusion)
+        dbt_version: dbt version to use
+        db_credentials: Database connection credentials
+
+    Returns:
+        Appropriate dbt runner fixture instance
+    """
+    if database == "fusion":
+        return DbtFusionRunnerFixture(dbt_version, db_credentials)
+
+    if database not in FIXTURE_CLASSES:
+        raise ValueError(
+            f"Unknown database type: {database}. "
+            f"Available: {list(FIXTURE_CLASSES.keys())}"
+        )
+
+    return DbtCoreRunnerFixture(database, dbt_version, db_credentials)


### PR DESCRIPTION
## Summary

Adds two new modules under `integration_tests/automated_tests/` that the testcontainers-based pytest harness can use to manage container lifecycles:

* **`database_fixtures.py`** — Postgres, Oracle, SQL Server container lifecycles via testcontainers-python. Per-fixture credentials generation and a uniform `get_credentials()` interface.
* **`dbt_fixtures.py`** — `DbtCoreRunnerFixture` and `DbtFusionRunnerFixture` built on testcontainers `DockerImage` / `DockerContainer`. Builds the runner image with cached Docker layers and exposes a `run_command` callable for each test.

These modules were already present in the working copy as untracked drafts. Splitting them onto their own branch so they can be reviewed independently of the recent issue #110 bugfix.

## Notes

* Not yet wired into `conftest.py` — committing as standalone modules first so the API surface can be reviewed.
* `ruff format` and `ruff lint` were applied via the pre-commit hooks; no functional changes.

## Test plan

- [x] `dbt parse` against `integration_tests/dbt-core` still succeeds (no import-time side effects from these modules)
- [ ] Reviewer to assess fixture API shape before wiring into `conftest.py` in a follow-up PR
- [ ] Smoke-test by invoking `DbtCoreRunnerFixture("snowflake", "1.9.0", creds)` from a one-off script to confirm container build + exec works
