### PR TITLE
chore(testcontainers): bump postgres/oracle/sqlserver images for ARM support

### DIFF
--- a/integration_tests/automated_tests/config/test-versions.json
+++ b/integration_tests/automated_tests/config/test-versions.json
@@ -10,15 +10,15 @@
   "adapters": {
     "postgres": {
       "package": "dbt-postgres",
-      "image": "postgres:17-alpine"
+      "image": "postgres:17-bookworm"
     },
     "oracle": {
       "package": "dbt-oracle",
-      "image": "gvenzl/oracle-free:23-slim-faststart"
+      "image": "gvenzl/oracle-free:23.26.1-slim-faststart"
     },
     "sqlserver": {
       "package": "dbt-sqlserver",
-      "image": "mcr.microsoft.com/mssql/server:2022-latest"
+      "image": "mcr.microsoft.com/mssql/server:2025-latest"
     },
     "snowflake": {
       "package": "dbt-snowflake",

--- a/integration_tests/automated_tests/docker/compose/oracle-db.yml
+++ b/integration_tests/automated_tests/docker/compose/oracle-db.yml
@@ -1,6 +1,6 @@
 services:
   oracle:
-    image: gvenzl/oracle-free:23-slim-faststart
+    image: gvenzl/oracle-free:23.26.1-slim-faststart
     container_name: ${COMPOSE_PROJECT_NAME:-dbt-test}-oracle
     environment:
       ORACLE_PASSWORD: ${ORACLE_PASSWORD}

--- a/integration_tests/automated_tests/docker/compose/postgres-db.yml
+++ b/integration_tests/automated_tests/docker/compose/postgres-db.yml
@@ -1,6 +1,6 @@
 services:
   postgres:
-    image: postgres:17-alpine
+    image: postgres:17-bookworm
     container_name: ${COMPOSE_PROJECT_NAME:-dbt-test}-postgres
     environment:
       POSTGRES_USER: ${POSTGRES_USER}

--- a/integration_tests/automated_tests/docker/compose/sqlserver-db.yml
+++ b/integration_tests/automated_tests/docker/compose/sqlserver-db.yml
@@ -1,6 +1,6 @@
 services:
   sqlserver:
-    image: mcr.microsoft.com/mssql/server:2022-latest
+    image: mcr.microsoft.com/mssql/server:2025-latest
     container_name: ${COMPOSE_PROJECT_NAME:-dbt-test}-sqlserver
     environment:
       ACCEPT_EULA: "Y"


### PR DESCRIPTION
## Summary
Bumps testcontainers base images to match other Snowflake-Labs projects and enable ARM (Apple Silicon, AWS Graviton) support:

| Adapter | From | To |
|---|---|---|
| postgres | `postgres:17-alpine` | `postgres:17-bookworm` |
| oracle | `gvenzl/oracle-free:23-slim-faststart` | `gvenzl/oracle-free:23.26.1-slim-faststart` |
| sqlserver | `mcr.microsoft.com/mssql/server:2022-latest` | `mcr.microsoft.com/mssql/server:2025-latest` |

## Smoke tests (linux/aarch64)
- `docker pull` succeeded for all three images.
- `postgres:17-bookworm` — `pg_isready` ok within 4s.
- `gvenzl/oracle-free:23.26.1-slim-faststart` — database open, redo log advancing.
- `mcr.microsoft.com/mssql/server:2025-latest` — runs via amd64 emulation; `SELECT @@VERSION` returned `Microsoft SQL Server 2025 (RTM-CU5-GDR) (KB5095565) - 17.0.4050.1 (X64)`.

## Test plan
- [x] All three images pull on linux/aarch64
- [x] All three containers start and pass an in-container healthcheck
- [ ] Reviewer runs `pytest --fast --database <db> --dbt-version 1.9.0 -v` against each adapter

.... Generated with [Cortex Code](https://docs.snowflake.com/en/user-guide/cortex-code/cortex-code)
