### PR TITLE
fix: 4 bug fixes for 1.0.9 (#85, #115, #117, #107)

### DIFF
--- a/macros/bigquery__create_constraints.sql
+++ b/macros/bigquery__create_constraints.sql
@@ -1,6 +1,6 @@
 {# Bigquery specific implementation to create a primary key #}
 {%- macro bigquery__create_primary_key(table_relation, column_names, verify_permissions, quote_columns, constraint_name, lookup_cache, rely_clause) -%}
-    {%- set constraint_name = (constraint_name or table_relation.identifier ~ "_" ~ column_names|join('_') ~ "_PK") | upper -%}
+    {%- set constraint_name = dbt_constraints.sanitize_constraint_name((constraint_name or table_relation.identifier ~ "_" ~ column_names|join('_') ~ "_PK")) -%}
     {%- set columns_csv = dbt_constraints.get_quoted_column_csv(column_names, quote_columns) -%}
 
     {#- Check that the table does not already have this PK/UK -#}
@@ -40,7 +40,7 @@
 
 {# Bigquery specific implementation to create a foreign key #}
 {%- macro bigquery__create_foreign_key(pk_table_relation, pk_column_names, fk_table_relation, fk_column_names, verify_permissions, quote_columns, constraint_name, lookup_cache, rely_clause) -%}
-    {%- set constraint_name = (constraint_name or fk_table_relation.identifier ~ "_" ~ fk_column_names|join('_') ~ "_FK") | upper -%}
+    {%- set constraint_name = dbt_constraints.sanitize_constraint_name((constraint_name or fk_table_relation.identifier ~ "_" ~ fk_column_names|join('_') ~ "_FK")) -%}
 
     {%- set fk_columns_csv = dbt_constraints.get_quoted_column_csv(fk_column_names, quote_columns) -%}
     {%- set pk_columns_csv = dbt_constraints.get_quoted_column_csv(pk_column_names, quote_columns) -%}

--- a/macros/create_constraints.sql
+++ b/macros/create_constraints.sql
@@ -375,7 +375,20 @@
                                 or ( dbt_constraints_sources_nn_enabled and test_name in("not_null") ) )
                         ) ) -%}
 
-                    {%- do node.update({'alias': node.alias or node.name }) -%}
+                    {#- Resolve the physical identifier, accounting for versioned models.
+                       For versioned models dbt materialises the table as `<name>_v<version>`,
+                       but `node.alias`/`node.name` may still be the unversioned form.
+                       Prefer `node.relation_name` (e.g. `"DB"."SCH"."MY_MODEL_V1"`) when set;
+                       otherwise append `_v<version>` if not already present. -#}
+                    {%- set _node_alias = node.alias or node.name -%}
+                    {%- if node.get('version') is not none -%}
+                        {%- if node.get('relation_name') -%}
+                            {%- set _node_alias = node.relation_name.split('.')[-1] | replace('"', '') -%}
+                        {%- elif not (_node_alias.endswith('_v' ~ node.version | string)) -%}
+                            {%- set _node_alias = _node_alias ~ '_v' ~ node.version -%}
+                        {%- endif -%}
+                    {%- endif -%}
+                    {%- do node.update({'alias': _node_alias}) -%}
                     {#- Append to our list of models for this test -#}
                     {%- do table_models.append(node) -%}
                     {%- if node.resource_type == "source"
@@ -495,10 +508,10 @@
                             {%- do dbt_constraints.create_foreign_key(pk_table_relation, pk_column_names, fk_table_relation, fk_column_names, ns.verify_permissions, quote_columns, test_parameters.constraint_name, lookup_cache, rely_clause) -%}
                         {%- endif -%}
                     {%- else  -%}
-                        {%- if fk_model == None or not fk_table_relation.is_table -%}
+                        {%- if fk_table_relation is none or not fk_table_relation.is_table -%}
                             {%- do log("Skipping foreign key to " ~ pk_model.alias ~ " because the child table was not found in the database: " ~ fk_model.alias, info=true) -%}
                         {%- endif -%}
-                        {%- if pk_model == None or not pk_model.is_table -%}
+                        {%- if pk_table_relation is none or not pk_table_relation.is_table -%}
                             {%- do log("Skipping foreign key on " ~ fk_model.alias ~ " because the parent table was not found in the database: " ~ pk_model.alias, info=true) -%}
                         {%- endif -%}
                     {%- endif -%}
@@ -567,6 +580,21 @@
 {%- endmacro -%}
 
 
+{#- Dispatch wrapper for `lookup_table_privileges`. Adapters that support privilege
+    introspection (Snowflake, Vertica) override this; others fall through to a
+    no-op that returns an empty list. The wrapper namespaces the call to the
+    `dbt_constraints` package, which is required when users invoke
+    `dbt_constraints.create_constraints()` directly from their own on-run-end. -#}
+{%- macro lookup_table_privileges(table_relation, lookup_cache) -%}
+    {{ return(adapter.dispatch('lookup_table_privileges', 'dbt_constraints')(table_relation, lookup_cache)) }}
+{%- endmacro -%}
+
+
+{%- macro default__lookup_table_privileges(table_relation, lookup_cache) -%}
+    {{ return([]) }}
+{%- endmacro -%}
+
+
 {%- macro default__lookup_table_columns(table_relation, lookup_cache) -%}
     {%- if table_relation not in lookup_cache.table_columns -%}
         {%- set tab_Columns = adapter.get_columns_in_relation(table_relation) -%}
@@ -595,6 +623,18 @@
         {%- do grouped[key].append(row) -%}
     {%- endfor -%}
     {{ return(grouped) }}
+{%- endmacro -%}
+
+
+{#- Sanitise an auto-generated constraint name so it is a legal unquoted SQL
+    identifier across all supported adapters. Strips double quotes and replaces
+    every other non-[A-Z0-9_$] character with `_`. Required when source columns
+    contain parentheses, spaces, dashes, dots, or other punctuation that would
+    otherwise be carried through into the generated `<TABLE>_<COL>_PK` name and
+    rejected as invalid identifier syntax (issue #107). -#}
+{%- macro sanitize_constraint_name(name) -%}
+    {%- set _name = name | upper | replace('"', '') -%}
+    {{ return(modules.re.sub('[^A-Z0-9_$]', '_', _name)) }}
 {%- endmacro -%}
 
 

--- a/macros/oracle__create_constraints.sql
+++ b/macros/oracle__create_constraints.sql
@@ -1,6 +1,6 @@
 {# Oracle specific implementation to create a primary key #}
 {%- macro oracle__create_primary_key(table_relation, column_names, verify_permissions, quote_columns, constraint_name, lookup_cache, rely_clause) -%}
-    {%- set constraint_name = (constraint_name or table_relation.identifier ~ "_" ~ column_names|join('_') ~ "_PK") | upper | replace('"', '') -%}
+    {%- set constraint_name = dbt_constraints.sanitize_constraint_name((constraint_name or table_relation.identifier ~ "_" ~ column_names|join('_') ~ "_PK")) -%}
 
     {%- if constraint_name|length > 30 %}
         {%- set constraint_name_query %}
@@ -43,7 +43,7 @@ END;
 
 {# Oracle specific implementation to create a unique key #}
 {%- macro oracle__create_unique_key(table_relation, column_names, verify_permissions, quote_columns, constraint_name, lookup_cache, rely_clause) -%}
-    {%- set constraint_name = (constraint_name or table_relation.identifier ~ "_" ~ column_names|join('_') ~ "_UK") | upper | replace('"', '') -%}
+    {%- set constraint_name = dbt_constraints.sanitize_constraint_name((constraint_name or table_relation.identifier ~ "_" ~ column_names|join('_') ~ "_UK")) -%}
 
     {%- if constraint_name|length > 30 %}
         {%- set constraint_name_query %}
@@ -86,7 +86,7 @@ END;
 
 {# Oracle specific implementation to create a foreign key #}
 {%- macro oracle__create_foreign_key(pk_table_relation, pk_column_names, fk_table_relation, fk_column_names, verify_permissions, quote_columns, constraint_name, lookup_cache, rely_clause) -%}
-    {%- set constraint_name = (constraint_name or fk_table_relation.identifier ~ "_" ~ fk_column_names|join('_') ~ "_FK") | upper | replace('"', '') -%}
+    {%- set constraint_name = dbt_constraints.sanitize_constraint_name((constraint_name or fk_table_relation.identifier ~ "_" ~ fk_column_names|join('_') ~ "_FK")) -%}
 
     {%- if constraint_name|length > 30 %}
         {%- set constraint_name_query %}

--- a/macros/postgres__create_constraints.sql
+++ b/macros/postgres__create_constraints.sql
@@ -1,6 +1,6 @@
 {# PostgreSQL specific implementation to create a primary key #}
 {%- macro postgres__create_primary_key(table_relation, column_names, verify_permissions, quote_columns, constraint_name, lookup_cache, rely_clause) -%}
-    {%- set constraint_name = (constraint_name or table_relation.identifier ~ "_" ~ column_names|join('_') ~ "_PK") | upper | replace('"', '') -%}
+    {%- set constraint_name = dbt_constraints.sanitize_constraint_name((constraint_name or table_relation.identifier ~ "_" ~ column_names|join('_') ~ "_PK")) -%}
 
     {%- if constraint_name|length > 63 %}
         {%- set constraint_name_query %}
@@ -37,7 +37,7 @@
 
 {# PostgreSQL specific implementation to create a unique key #}
 {%- macro postgres__create_unique_key(table_relation, column_names, verify_permissions, quote_columns, constraint_name, lookup_cache, rely_clause) -%}
-    {%- set constraint_name = (constraint_name or table_relation.identifier ~ "_" ~ column_names|join('_') ~ "_UK") | upper | replace('"', '') -%}
+    {%- set constraint_name = dbt_constraints.sanitize_constraint_name((constraint_name or table_relation.identifier ~ "_" ~ column_names|join('_') ~ "_UK")) -%}
 
     {%- if constraint_name|length > 63 %}
         {%- set constraint_name_query %}
@@ -94,7 +94,7 @@
 
 {# PostgreSQL specific implementation to create a foreign key #}
 {%- macro postgres__create_foreign_key(pk_table_relation, pk_column_names, fk_table_relation, fk_column_names, verify_permissions, quote_columns, constraint_name, lookup_cache, rely_clause) -%}
-    {%- set constraint_name = (constraint_name or fk_table_relation.identifier ~ "_" ~ fk_column_names|join('_') ~ "_FK") | upper | replace('"', '') -%}
+    {%- set constraint_name = dbt_constraints.sanitize_constraint_name((constraint_name or fk_table_relation.identifier ~ "_" ~ fk_column_names|join('_') ~ "_FK")) -%}
 
     {%- if constraint_name|length > 63 %}
         {%- set constraint_name_query %}

--- a/macros/redshift__create_constraints.sql
+++ b/macros/redshift__create_constraints.sql
@@ -1,6 +1,6 @@
 {# Redshift specific implementation to create a primary key #}
 {%- macro redshift__create_primary_key(table_relation, column_names, verify_permissions, quote_columns, constraint_name, lookup_cache, rely_clause) -%}
-    {%- set constraint_name = (constraint_name or table_relation.identifier ~ "_" ~ column_names|join('_') ~ "_PK") | upper | replace('"', '') -%}
+    {%- set constraint_name = dbt_constraints.sanitize_constraint_name((constraint_name or table_relation.identifier ~ "_" ~ column_names|join('_') ~ "_PK")) -%}
 
     {%- if constraint_name|length > 127 %}
         {%- set constraint_name_query %}
@@ -37,7 +37,7 @@
 
 {# Redshift specific implementation to create a unique key #}
 {%- macro redshift__create_unique_key(table_relation, column_names, verify_permissions, quote_columns, constraint_name, lookup_cache, rely_clause) -%}
-    {%- set constraint_name = (constraint_name or table_relation.identifier ~ "_" ~ column_names|join('_') ~ "_UK") | upper | replace('"', '') -%}
+    {%- set constraint_name = dbt_constraints.sanitize_constraint_name((constraint_name or table_relation.identifier ~ "_" ~ column_names|join('_') ~ "_UK")) -%}
 
     {%- if constraint_name|length > 127 %}
         {%- set constraint_name_query %}
@@ -79,7 +79,7 @@
 
 {# Redshift specific implementation to create a foreign key #}
 {%- macro redshift__create_foreign_key(pk_table_relation, pk_column_names, fk_table_relation, fk_column_names, verify_permissions, quote_columns, constraint_name, lookup_cache, rely_clause) -%}
-    {%- set constraint_name = (constraint_name or fk_table_relation.identifier ~ "_" ~ fk_column_names|join('_') ~ "_FK") | upper | replace('"', '') -%}
+    {%- set constraint_name = dbt_constraints.sanitize_constraint_name((constraint_name or fk_table_relation.identifier ~ "_" ~ fk_column_names|join('_') ~ "_FK")) -%}
 
     {%- if constraint_name|length > 127 %}
         {%- set constraint_name_query %}

--- a/macros/snowflake__create_constraints.sql
+++ b/macros/snowflake__create_constraints.sql
@@ -16,7 +16,7 @@
 
 {# Snowflake specific implementation to create a primary key #}
 {%- macro snowflake__create_primary_key(table_relation, column_names, verify_permissions, quote_columns, constraint_name, lookup_cache, rely_clause) -%}
-    {%- set constraint_name = (constraint_name or table_relation.identifier ~ "_" ~ column_names|join('_') ~ "_PK") | upper | replace('"', '') -%}
+    {%- set constraint_name = dbt_constraints.sanitize_constraint_name((constraint_name or table_relation.identifier ~ "_" ~ column_names|join('_') ~ "_PK")) -%}
     {%- set columns_csv = dbt_constraints.get_quoted_column_csv(column_names, quote_columns) -%}
 
     {#- Check that the table does not already have this PK/UK -#}
@@ -62,7 +62,7 @@
 
 {# Snowflake specific implementation to create a unique key #}
 {%- macro snowflake__create_unique_key(table_relation, column_names, verify_permissions, quote_columns, constraint_name, lookup_cache, rely_clause) -%}
-    {%- set constraint_name = (constraint_name or table_relation.identifier ~ "_" ~ column_names|join('_') ~ "_UK") | upper | replace('"', '') -%}
+    {%- set constraint_name = dbt_constraints.sanitize_constraint_name((constraint_name or table_relation.identifier ~ "_" ~ column_names|join('_') ~ "_UK")) -%}
     {%- set columns_csv = dbt_constraints.get_quoted_column_csv(column_names, quote_columns) -%}
 
     {#- Check that the table does not already have this PK/UK -#}
@@ -108,7 +108,7 @@
 
 {# Snowflake specific implementation to create a foreign key #}
 {%- macro snowflake__create_foreign_key(pk_table_relation, pk_column_names, fk_table_relation, fk_column_names, verify_permissions, quote_columns, constraint_name, lookup_cache, rely_clause) -%}
-{%- set constraint_name = (constraint_name or fk_table_relation.identifier ~ "_" ~ fk_column_names|join('_') ~ "_FK") | upper | replace('"', '') -%}
+{%- set constraint_name = dbt_constraints.sanitize_constraint_name((constraint_name or fk_table_relation.identifier ~ "_" ~ fk_column_names|join('_') ~ "_FK")) -%}
 {%- set fk_columns_csv = dbt_constraints.get_quoted_column_csv(fk_column_names, quote_columns) -%}
 {%- set pk_columns_csv = dbt_constraints.get_quoted_column_csv(pk_column_names, quote_columns) -%}
 
@@ -350,7 +350,7 @@ SHOW IMPORTED KEYS IN TABLE {{ table_relation }}
 {%- macro snowflake__have_references_priv(table_relation, verify_permissions, lookup_cache) -%}
 {%- if verify_permissions is sameas true -%}
 
-{%- set table_privileges = snowflake__lookup_table_privileges(table_relation, lookup_cache) -%}
+{%- set table_privileges = dbt_constraints.lookup_table_privileges(table_relation, lookup_cache) -%}
 {%- if "REFERENCES" in table_privileges or "OWNERSHIP" in table_privileges -%}
             {{ return(true) }}
         {%- else -%}
@@ -367,7 +367,7 @@ SHOW IMPORTED KEYS IN TABLE {{ table_relation }}
 {%- macro snowflake__have_ownership_priv(table_relation, verify_permissions, lookup_cache) -%}
 {%- if verify_permissions is sameas true -%}
 
-{%- set table_privileges = snowflake__lookup_table_privileges(table_relation, lookup_cache) -%}
+{%- set table_privileges = dbt_constraints.lookup_table_privileges(table_relation, lookup_cache) -%}
 {%- if "OWNERSHIP" in table_privileges -%}
             {{ return(true) }}
         {%- else -%}

--- a/macros/vertica__create_constraints.sql
+++ b/macros/vertica__create_constraints.sql
@@ -1,6 +1,6 @@
 {# Vertica specific implementation to create a primary key #}
 {%- macro vertica__create_primary_key(table_relation, column_names, verify_permissions, quote_columns, constraint_name, lookup_cache, rely_clause) -%}
-    {%- set constraint_name = (constraint_name or table_relation.identifier ~ "_" ~ column_names|join('_') ~ "_PK") | upper | replace('"', '') -%}
+    {%- set constraint_name = dbt_constraints.sanitize_constraint_name((constraint_name or table_relation.identifier ~ "_" ~ column_names|join('_') ~ "_PK")) -%}
     {%- set columns_csv = dbt_constraints.get_quoted_column_csv(column_names, quote_columns) -%}
 
     {#- Check that the table does not already have this PK/UK -#}
@@ -29,7 +29,7 @@
 
 {# Vertica specific implementation to create a unique key #}
 {%- macro vertica__create_unique_key(table_relation, column_names, verify_permissions, quote_columns, constraint_name, lookup_cache, rely_clause) -%}
-    {%- set constraint_name = (constraint_name or table_relation.identifier ~ "_" ~ column_names|join('_') ~ "_UK") | upper | replace('"', '') -%}
+    {%- set constraint_name = dbt_constraints.sanitize_constraint_name((constraint_name or table_relation.identifier ~ "_" ~ column_names|join('_') ~ "_UK")) -%}
     {%- set columns_csv = dbt_constraints.get_quoted_column_csv(column_names, quote_columns) -%}
 
     {#- Check that the table does not already have this PK/UK -#}
@@ -58,7 +58,7 @@
 
 {# Vertica specific implementation to create a foreign key #}
 {%- macro vertica__create_foreign_key(pk_table_relation, pk_column_names, fk_table_relation, fk_column_names, verify_permissions, quote_columns, constraint_name, lookup_cache, rely_clause) -%}
-    {%- set constraint_name = (constraint_name or fk_table_relation.identifier ~ "_" ~ fk_column_names|join('_') ~ "_FK") | upper | replace('"', '') -%}
+    {%- set constraint_name = dbt_constraints.sanitize_constraint_name((constraint_name or fk_table_relation.identifier ~ "_" ~ fk_column_names|join('_') ~ "_FK")) -%}
     {%- set fk_columns_csv = dbt_constraints.get_quoted_column_csv(fk_column_names, quote_columns) -%}
     {%- set pk_columns_csv = dbt_constraints.get_quoted_column_csv(pk_column_names, quote_columns) -%}
     {#- Check that the PK table has a PK or UK -#}
@@ -251,7 +251,7 @@
 {%- macro vertica__have_references_priv(table_relation, verify_permissions, lookup_cache) -%}
     {%- if verify_permissions is sameas true -%}
 
-        {%- set table_privileges = vertica__lookup_table_privileges(table_relation, lookup_cache) -%}
+        {%- set table_privileges = dbt_constraints.lookup_table_privileges(table_relation, lookup_cache) -%}
         {%- if "REFERENCES" in table_privileges or "OWNERSHIP" in table_privileges -%}
             {{ return(true) }}
         {%- else -%}
@@ -268,7 +268,7 @@
 {%- macro vertica__have_ownership_priv(table_relation, verify_permissions, lookup_cache) -%}
     {%- if verify_permissions is sameas true -%}
 
-        {%- set table_privileges = vertica__lookup_table_privileges(table_relation, lookup_cache) -%}
+        {%- set table_privileges = dbt_constraints.lookup_table_privileges(table_relation, lookup_cache) -%}
         {%- if "OWNERSHIP" in table_privileges -%}
             {{ return(true) }}
         {%- else -%}


### PR DESCRIPTION
## Summary
Bundles 4 independent bug fixes for 1.0.9. All pre-merge gates green on dbt Fusion `2.0.0-preview.178` against Snowflake (aws_cas2): 165 total, 153 success, 12 intentional warns, 0 errors.

| Issue | Fix |
|---|---|
| **#85** | Fix two var-name bugs in `create_constraints.sql:498,501` (`fk_table_relation.is_table` crash on None; `pk_model.is_table` doesn't exist — should be `pk_table_relation`). FK creation now skips with a clear log when the parent table is missing instead of raising UndefinedError. |
| **#115** | Versioned dbt models materialise as `<name>_v<version>` but the package was looking up the unversioned identifier. Fix: prefer `node.relation_name.split('.')[-1] | replace('"','')` when `node.version` is set; falls back to `<name>_v<version>` if `relation_name` absent. NOT NULL / PK / UK / FK constraints now create on versioned models. |
| **#117** | `lookup_table_privileges` lacked a public dispatch wrapper, so the four bare-name call sites in `snowflake__` and `vertica__` adapters broke when users called `dbt_constraints.create_constraints()` from their own project's on-run-end. Fix: add `lookup_table_privileges` + `default__lookup_table_privileges` wrapper in `create_constraints.sql`; route call sites through `dbt_constraints.lookup_table_privileges(...)`. |
| **#107** | Auto-generated constraint names only stripped `"`; columns with parens/spaces/dashes/dots produced invalid identifier DDL. Fix: add `dbt_constraints.sanitize_constraint_name()` helper (uppercase, strip `"`, regex `[^A-Z0-9_$] -> _`). Update all 17 inline constraint-name expressions across snowflake / postgres / oracle / redshift / bigquery / vertica adapters to call the helper. Runs **before** the postgres/oracle length-truncation/`ora_hash` fallback so the truncated identifier is always valid. |

## Note on #108
C3 (#108 HAVING `quote_columns: True` regression coverage) was investigated and dropped from this PR. The current `default__test_primary_key/_unique_key` already drive HAVING through `prefixed_columns_list` which is correctly quoted. The fixture I tried to add to `dim_part.TitleCasePartKey` produced syntax errors due to a separate double-quoting interaction with the `quote: true` model column property. Leaving #108 open for follow-up — the underlying code is fine, but the test fixture for it needs more thought.

## Test plan
- [x] Pre-fix repro: each issue's failure mode reproduced on `main` with `dbtf build`.
- [x] Post-fix verification: full Fusion build green (165 total, 153 success, 12 intentional warns, 0 errors) against Snowflake aws_cas2.
- [x] `assert_fk_parity.sql` passes after on-run-end completes.
- [ ] Reviewer runs `pytest --database <db> --dbt-version 1.9.0 -v` against Postgres / Oracle / SQL Server using the new ARM-compatible images from #125.

Fixes #85
Fixes #115
Fixes #117
Fixes #107

.... Generated with [Cortex Code](https://docs.snowflake.com/en/user-guide/cortex-code/cortex-code)
