### PR TITLE
fix(snowflake): quote constraint name in set_rely_norely DDL

### DIFF
--- a/macros/snowflake__create_constraints.sql
+++ b/macros/snowflake__create_constraints.sql
@@ -215,7 +215,7 @@
             or ( rely_clause == 'RELY' and constraint_rely == 'false' ) -%}
         {%- set ddl_prefix_for_alter = 'ICEBERG' if table_relation.is_iceberg_format else '' -%}
         {%- set query -%}
-        ALTER {{ ddl_prefix_for_alter }} TABLE {{ table_relation }} MODIFY CONSTRAINT {{ constraint_name }} {{ rely_clause }}
+        ALTER {{ ddl_prefix_for_alter }} TABLE {{ table_relation }} MODIFY CONSTRAINT "{{ constraint_name }}" {{ rely_clause }}
         {%- endset -%}
         {%- do log("Updating constraint: " ~ constraint_name ~ " " ~ rely_clause, info=true) -%}
         {%- do run_query(query) -%}


### PR DESCRIPTION
Fixes #127.

## Problem

Running `dbt build` with `dbt_constraints` 1.0.9 raises a SQL compilation error when a table has constraints whose names were auto-generated by Snowflake:

```
syntax error line 1 at position 109 unexpected '-'.
```

The DDL being emitted is:

```sql
ALTER TABLE <table> MODIFY CONSTRAINT SYS_CONSTRAINT_59eea5c2-a1d8-45d9-9cc0-17246bc52fce RELY
```

Snowflake auto-names constraints as `SYS_CONSTRAINT_<uuid>`. The UUID contains hyphens, which are illegal in unquoted SQL identifiers, hence the parse error.

## How the regression was introduced

This bug is the result of two changes across two releases:

**1.0.5 — `f60652b` ("Fixed metadata caching for Snowflake")** introduced a metadata-cache lookup for existing constraints. When the cache found that a PK/UK/FK already existed on a table, it skipped the constraint creation and logged `"Skipping … because PK/UK already exists"` — but it also silently stopped calling `set_rely_norely()` for that constraint. This meant RELY/NORELY was never flipped on existing constraints, which was a correctness bug (tracked in #110).

**1.0.9 — PR #121 (`2f18866`, "fix(snowflake): restore RELY/NORELY flip on existing constraints")** correctly restored the `set_rely_norely()` call for the cache-hit path, passing the *actual* constraint name read from `SHOW UNIQUE/PRIMARY KEYS`. For user-named constraints this works fine. But for constraints dbt never explicitly named, Snowflake assigns a `SYS_CONSTRAINT_<uuid>` name — and `set_rely_norely` emits that name unquoted:

```sql
-- macros/snowflake__create_constraints.sql
ALTER TABLE {{ table_relation }} MODIFY CONSTRAINT {{ constraint_name }} {{ rely_clause }}
```

Before 1.0.9, this code path was never reached for auto-named constraints (the cache-hit branch skipped `set_rely_norely` entirely), so the quoting gap was latent. PR #121 activated it and surfaced the bug.

## Fix

Wrap the constraint name in double quotes so that any valid Snowflake identifier — including system-generated names with hyphens — is quoted correctly:

```diff
- ALTER {{ ddl_prefix_for_alter }} TABLE {{ table_relation }} MODIFY CONSTRAINT {{ constraint_name }} {{ rely_clause }}
+ ALTER {{ ddl_prefix_for_alter }} TABLE {{ table_relation }} MODIFY CONSTRAINT "{{ constraint_name }}" {{ rely_clause }}
```

Double-quoting is safe for user-defined names too, as Snowflake treats quoted and unquoted identifiers the same when the name contains only alphanumerics and underscores.